### PR TITLE
Logout from homepage if token expired. Replicate across other pages?

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -26,6 +26,7 @@ const Home = () => {
           setUsername(data.name);
         } else {
           alert('Failed to fetch username');
+          navigate('/');
         }
         setLoading(false);
       })


### PR DESCRIPTION
User should not be able to be inside the application if they are not logged in (no JWT token that is active).